### PR TITLE
Add Tailscale Kubernetes Operator proxy architecture diagram

### DIFF
--- a/content/diagrams/network/tailscale-k8s-operator-proxy/index.md
+++ b/content/diagrams/network/tailscale-k8s-operator-proxy/index.md
@@ -1,0 +1,17 @@
+---
+title: "Tailscale Kubernetes Operator Proxy Architecture"
+description: "Technical diagram showing Tailscale Kubernetes Operator ingress and egress proxy flows for connecting external Tailscale clients to K8s services and K8s workloads to external resources"
+date: 2025-07-23
+categories: ["network"]
+tags: ["tailscale", "kubernetes", "operator", "proxy", "ingress", "egress", "service-mesh"]
+---
+
+This diagram illustrates the Tailscale Kubernetes Operator proxy architecture, showing:
+
+- **Ingress Proxy**: External Tailscale clients accessing Kubernetes services through proxy pods
+- **Egress Proxy**: Kubernetes workloads connecting to external Tailscale resources
+- **ProxyClass Resources**: Configuration management for different proxy types
+- **Operator Controller**: Automated deployment and management of proxy pods
+- **Traffic Flows**: Secure WireGuard tunnels for both inbound and outbound connections
+
+The operator enables seamless integration between Tailscale's zero-trust network and Kubernetes clusters, providing secure connectivity without complex networking configurations.

--- a/content/diagrams/network/tailscale-k8s-operator-proxy/tailscale-k8s-operator-proxy.svg
+++ b/content/diagrams/network/tailscale-k8s-operator-proxy/tailscale-k8s-operator-proxy.svg
@@ -1,0 +1,160 @@
+<svg width="1100" height="800" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1100" height="800" fill="#f8f9fa"/>
+  
+  <!-- Title -->
+  <text x="550" y="35" text-anchor="middle" font-family="Arial, sans-serif" font-size="24" font-weight="bold">Tailscale Kubernetes Operator Proxy Architecture</text>
+  
+  <!-- External Tailscale Network -->
+  <rect x="50" y="80" width="300" height="200" fill="#e3f2fd" stroke="#2196f3" stroke-width="2" rx="10" stroke-dasharray="5,5"/>
+  <text x="200" y="105" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="#1976d2">Tailscale Network</text>
+  
+  <!-- External Clients -->
+  <rect x="80" y="130" width="80" height="50" fill="#2196f3" stroke="#1976d2" stroke-width="2" rx="5"/>
+  <text x="120" y="150" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white" font-weight="bold">Laptop</text>
+  <text x="120" y="165" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#e3f2fd">100.64.1.5</text>
+  
+  <rect x="200" y="130" width="80" height="50" fill="#2196f3" stroke="#1976d2" stroke-width="2" rx="5"/>
+  <text x="240" y="150" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white" font-weight="bold">Phone</text>
+  <text x="240" y="165" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#e3f2fd">100.64.1.8</text>
+  
+  <!-- External Services -->
+  <rect x="80" y="210" width="80" height="50" fill="#9c27b0" stroke="#7b1fa2" stroke-width="2" rx="5"/>
+  <text x="120" y="230" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white" font-weight="bold">Database</text>
+  <text x="120" y="245" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#f3e5f5">100.64.2.10</text>
+  
+  <rect x="200" y="210" width="80" height="50" fill="#9c27b0" stroke="#7b1fa2" stroke-width="2" rx="5"/>
+  <text x="240" y="230" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white" font-weight="bold">API Server</text>
+  <text x="240" y="245" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#f3e5f5">100.64.2.15</text>
+  
+  <!-- Kubernetes Cluster -->
+  <rect x="450" y="80" width="600" height="600" fill="#e8f5e9" stroke="#4caf50" stroke-width="3" rx="10"/>
+  <text x="750" y="105" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="#2e7d32">Kubernetes Cluster</text>
+  
+  <!-- Tailscale Operator -->
+  <rect x="480" y="130" width="160" height="80" fill="#1a1a1a" stroke="#000" stroke-width="2" rx="5"/>
+  <text x="560" y="155" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="white" font-weight="bold">Tailscale Operator</text>
+  <text x="560" y="175" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#ccc">Controller</text>
+  <text x="560" y="190" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#999">Manages ProxyClass &amp; Proxies</text>
+  
+  <!-- ProxyClass Resources -->
+  <rect x="480" y="240" width="160" height="60" fill="#ff9800" stroke="#f57c00" stroke-width="2" rx="5"/>
+  <text x="560" y="265" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="white" font-weight="bold">ProxyClass</text>
+  <text x="560" y="285" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white">ingress-proxy</text>
+  
+  <!-- Ingress Proxy Pods -->
+  <g id="ingress-proxies">
+    <rect x="700" y="180" width="120" height="80" fill="#2196f3" stroke="#1976d2" stroke-width="2" rx="5"/>
+    <text x="760" y="205" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white" font-weight="bold">Ingress Proxy</text>
+    <text x="760" y="225" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#e3f2fd">web-service</text>
+    <text x="760" y="240" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#bbdefb">100.64.0.10</text>
+    <text x="760" y="255" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#90caf9">Port: 80</text>
+    
+    <rect x="870" y="180" width="120" height="80" fill="#2196f3" stroke="#1976d2" stroke-width="2" rx="5"/>
+    <text x="930" y="205" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white" font-weight="bold">Ingress Proxy</text>
+    <text x="930" y="225" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#e3f2fd">api-service</text>
+    <text x="930" y="240" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#bbdefb">100.64.0.12</text>
+    <text x="930" y="255" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#90caf9">Port: 8080</text>
+  </g>
+  
+  <!-- Kubernetes Services -->
+  <g id="k8s-services">
+    <rect x="700" y="320" width="120" height="60" fill="#4caf50" stroke="#388e3c" stroke-width="2" rx="5"/>
+    <text x="760" y="345" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white" font-weight="bold">web-service</text>
+    <text x="760" y="365" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#e8f5e9">ClusterIP</text>
+    
+    <rect x="870" y="320" width="120" height="60" fill="#4caf50" stroke="#388e3c" stroke-width="2" rx="5"/>
+    <text x="930" y="345" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white" font-weight="bold">api-service</text>
+    <text x="930" y="365" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#e8f5e9">ClusterIP</text>
+  </g>
+  
+  <!-- Application Pods -->
+  <g id="app-pods">
+    <rect x="700" y="420" width="120" height="60" fill="#607d8b" stroke="#455a64" stroke-width="2" rx="5"/>
+    <text x="760" y="445" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white" font-weight="bold">web-app</text>
+    <text x="760" y="465" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#cfd8dc">Pod</text>
+    
+    <rect x="870" y="420" width="120" height="60" fill="#607d8b" stroke="#455a64" stroke-width="2" rx="5"/>
+    <text x="930" y="445" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white" font-weight="bold">api-app</text>
+    <text x="930" y="465" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#cfd8dc">Pod</text>
+  </g>
+  
+  <!-- Egress Proxy -->
+  <rect x="480" y="520" width="160" height="80" fill="#ff5722" stroke="#d84315" stroke-width="2" rx="5"/>
+  <text x="560" y="545" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="white" font-weight="bold">Egress Proxy</text>
+  <text x="560" y="565" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#ffccbc">external-access</text>
+  <text x="560" y="580" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#ffab91">Routes to External</text>
+  
+  <!-- Client Pod needing external access -->
+  <rect x="700" y="530" width="120" height="60" fill="#795548" stroke="#5d4037" stroke-width="2" rx="5"/>
+  <text x="760" y="555" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white" font-weight="bold">client-pod</text>
+  <text x="760" y="575" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#d7ccc8">Needs External DB</text>
+  
+  <!-- Ingress Flow Arrows -->
+  <g id="ingress-flow" stroke="#2196f3" stroke-width="3" fill="none" marker-end="url(#arrowhead-blue)">
+    <path d="M 350 155 Q 400 155 450 155 Q 500 155 580 155 Q 650 155 700 200"/>
+    <path d="M 350 240 Q 400 240 450 240 Q 500 240 580 240 Q 650 240 870 220"/>
+  </g>
+  
+  <!-- Service to Pod Arrows -->
+  <g id="service-pod-flow" stroke="#4caf50" stroke-width="2" fill="none" marker-end="url(#arrowhead-green)">
+    <line x1="760" y1="320" x2="760" y2="420"/>
+    <line x1="930" y1="320" x2="930" y2="420"/>
+    <line x1="760" y1="260" x2="760" y2="320"/>
+    <line x1="930" y1="260" x2="930" y2="320"/>
+  </g>
+  
+  <!-- Egress Flow Arrows -->
+  <g id="egress-flow" stroke="#ff5722" stroke-width="3" fill="none" marker-end="url(#arrowhead-red)">
+    <path d="M 700 560 Q 650 560 600 560 Q 580 560 560 560"/>
+    <path d="M 480 560 Q 400 560 350 560 Q 300 560 200 235 Q 160 235 160 210"/>
+  </g>
+  
+  <!-- Control Flow from Operator -->
+  <g id="control-flow" stroke="#666" stroke-width="1" fill="none" stroke-dasharray="2,2">
+    <line x1="560" y1="210" x2="560" y2="240"/>
+    <line x1="640" y1="170" x2="700" y2="200"/>
+    <line x1="640" y1="170" x2="870" y2="200"/>
+    <line x1="560" y1="210" x2="560" y2="520"/>
+  </g>
+  
+  <!-- Arrow markers -->
+  <defs>
+    <marker id="arrowhead-blue" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2196f3"/>
+    </marker>
+    <marker id="arrowhead-green" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#4caf50"/>
+    </marker>
+    <marker id="arrowhead-red" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#ff5722"/>
+    </marker>
+  </defs>
+  
+  <!-- Flow Labels -->
+  <text x="525" y="140" font-family="Arial, sans-serif" font-size="11" fill="#2196f3" font-weight="bold">Ingress Traffic</text>
+  <text x="400" y="580" font-family="Arial, sans-serif" font-size="11" fill="#ff5722" font-weight="bold">Egress Traffic</text>
+  <text x="580" y="290" font-family="Arial, sans-serif" font-size="10" fill="#666">Control</text>
+  
+  <!-- Legend -->
+  <g id="legend" transform="translate(50, 720)">
+    <text x="0" y="0" font-family="Arial, sans-serif" font-size="14" font-weight="bold">Traffic Flows:</text>
+    
+    <line x1="0" y1="20" x2="40" y2="20" stroke="#2196f3" stroke-width="3" marker-end="url(#arrowhead-blue)"/>
+    <text x="50" y="25" font-family="Arial, sans-serif" font-size="12">Ingress: External → K8s Services</text>
+    
+    <line x1="0" y1="40" x2="40" y2="40" stroke="#ff5722" stroke-width="3" marker-end="url(#arrowhead-red)"/>
+    <text x="50" y="45" font-family="Arial, sans-serif" font-size="12">Egress: K8s Pods → External Resources</text>
+    
+    <line x1="0" y1="60" x2="40" y2="60" stroke="#666" stroke-width="1" stroke-dasharray="2,2"/>
+    <text x="50" y="65" font-family="Arial, sans-serif" font-size="12">Control: Operator Management</text>
+  </g>
+  
+  <!-- Features Box -->
+  <rect x="750" y="620" width="320" height="140" fill="#f5f5f5" stroke="#ddd" stroke-width="1" rx="5"/>
+  <text x="910" y="645" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" font-weight="bold">Operator Features</text>
+  <text x="770" y="670" font-family="Arial, sans-serif" font-size="12">• Automatic proxy pod deployment</text>
+  <text x="770" y="690" font-family="Arial, sans-serif" font-size="12">• Service discovery integration</text>
+  <text x="770" y="710" font-family="Arial, sans-serif" font-size="12">• ProxyClass resource management</text>
+  <text x="770" y="730" font-family="Arial, sans-serif" font-size="12">• Ingress annotation support</text>
+  <text x="770" y="750" font-family="Arial, sans-serif" font-size="12">• Subnet routing capabilities</text>
+</svg>


### PR DESCRIPTION
This PR adds a comprehensive technical diagram showing the Tailscale Kubernetes Operator proxy architecture, including both ingress and egress proxy flows.

The diagram illustrates:
- External Tailscale clients accessing Kubernetes services through ingress proxies
- Kubernetes workloads connecting to external Tailscale resources via egress proxies
- Operator controller managing ProxyClass resources and proxy pod deployment
- Traffic flows and networking architecture

Closes #3

Generated with [Claude Code](https://claude.ai/code)