### PR TITLE
Fix Tailscale K8s operator diagram layering and Tailnet visualization

### DIFF
--- a/content/diagrams/network/tailscale-k8s-operator-proxy/tailscale-k8s-operator-proxy.svg
+++ b/content/diagrams/network/tailscale-k8s-operator-proxy/tailscale-k8s-operator-proxy.svg
@@ -1,12 +1,28 @@
-<svg width="1100" height="800" xmlns="http://www.w3.org/2000/svg">
-  <rect width="1100" height="800" fill="#f8f9fa"/>
+<svg width="1100" height="900" viewBox="0 0 1100 900" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1100" height="900" fill="#f8f9fa"/>
+  
+  <!-- Arrow markers (must be defined first) -->
+  <defs>
+    <marker id="arrowhead-blue" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2196f3"/>
+    </marker>
+    <marker id="arrowhead-green" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#4caf50"/>
+    </marker>
+    <marker id="arrowhead-red" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#ff5722"/>
+    </marker>
+    <marker id="arrowhead-tailnet" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#673ab7"/>
+    </marker>
+  </defs>
   
   <!-- Title -->
   <text x="550" y="35" text-anchor="middle" font-family="Arial, sans-serif" font-size="24" font-weight="bold">Tailscale Kubernetes Operator Proxy Architecture</text>
   
   <!-- External Tailscale Network -->
   <rect x="50" y="80" width="300" height="200" fill="#e3f2fd" stroke="#2196f3" stroke-width="2" rx="10" stroke-dasharray="5,5"/>
-  <text x="200" y="105" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="#1976d2">Tailscale Network</text>
+  <text x="200" y="105" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="#1976d2">Tailscale Network (Tailnet)</text>
   
   <!-- External Clients -->
   <rect x="80" y="130" width="80" height="50" fill="#2196f3" stroke="#1976d2" stroke-width="2" rx="5"/>
@@ -41,15 +57,41 @@
   <text x="560" y="265" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="white" font-weight="bold">ProxyClass</text>
   <text x="560" y="285" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white">ingress-proxy</text>
   
-  <!-- Ingress Proxy Pods -->
+  <!-- Background arrows (drawn behind other elements) -->
+  <g id="background-arrows">
+    <!-- Tailnet connection to proxies (behind elements) -->
+    <g stroke="#673ab7" stroke-width="3" fill="none" stroke-dasharray="10,5" marker-end="url(#arrowhead-tailnet)">
+      <path d="M 350 180 L 450 180 L 700 180"/>
+      <path d="M 350 230 L 450 230 L 870 180"/>
+      <path d="M 350 240 L 450 560"/>
+    </g>
+    
+    <!-- Ingress Flow Arrows (behind elements) -->
+    <g stroke="#2196f3" stroke-width="3" fill="none" marker-end="url(#arrowhead-blue)">
+      <line x1="280" y1="155" x2="700" y2="155"/>
+      <line x1="280" y1="155" x2="870" y2="155"/>
+    </g>
+    
+    <!-- Egress Flow Arrows (behind elements) -->
+    <g stroke="#ff5722" stroke-width="3" fill="none" marker-end="url(#arrowhead-red)">
+      <line x1="700" y1="560" x2="640" y2="560"/>
+      <line x1="480" y1="560" x2="280" y2="235"/>
+    </g>
+  </g>
+  
+  <!-- Ingress Proxy Pods (with Tailnet connection indicators) -->
   <g id="ingress-proxies">
     <rect x="700" y="180" width="120" height="80" fill="#2196f3" stroke="#1976d2" stroke-width="2" rx="5"/>
+    <circle cx="690" cy="220" r="8" fill="#673ab7" stroke="#4a148c" stroke-width="2"/>
+    <text x="690" y="224" text-anchor="middle" font-family="Arial, sans-serif" font-size="8" fill="white" font-weight="bold">T</text>
     <text x="760" y="205" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white" font-weight="bold">Ingress Proxy</text>
     <text x="760" y="225" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#e3f2fd">web-service</text>
     <text x="760" y="240" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#bbdefb">100.64.0.10</text>
     <text x="760" y="255" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#90caf9">Port: 80</text>
     
     <rect x="870" y="180" width="120" height="80" fill="#2196f3" stroke="#1976d2" stroke-width="2" rx="5"/>
+    <circle cx="860" cy="220" r="8" fill="#673ab7" stroke="#4a148c" stroke-width="2"/>
+    <text x="860" y="224" text-anchor="middle" font-family="Arial, sans-serif" font-size="8" fill="white" font-weight="bold">T</text>
     <text x="930" y="205" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white" font-weight="bold">Ingress Proxy</text>
     <text x="930" y="225" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#e3f2fd">api-service</text>
     <text x="930" y="240" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#bbdefb">100.64.0.12</text>
@@ -78,8 +120,10 @@
     <text x="930" y="465" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#cfd8dc">Pod</text>
   </g>
   
-  <!-- Egress Proxy -->
+  <!-- Egress Proxy (with Tailnet connection indicator) -->
   <rect x="480" y="520" width="160" height="80" fill="#ff5722" stroke="#d84315" stroke-width="2" rx="5"/>
+  <circle cx="470" cy="560" r="8" fill="#673ab7" stroke="#4a148c" stroke-width="2"/>
+  <text x="470" y="564" text-anchor="middle" font-family="Arial, sans-serif" font-size="8" fill="white" font-weight="bold">T</text>
   <text x="560" y="545" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="white" font-weight="bold">Egress Proxy</text>
   <text x="560" y="565" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#ffccbc">external-access</text>
   <text x="560" y="580" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#ffab91">Routes to External</text>
@@ -89,54 +133,33 @@
   <text x="760" y="555" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white" font-weight="bold">client-pod</text>
   <text x="760" y="575" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#d7ccc8">Needs External DB</text>
   
-  <!-- Ingress Flow Arrows -->
-  <g id="ingress-flow" stroke="#2196f3" stroke-width="3" fill="none" marker-end="url(#arrowhead-blue)">
-    <path d="M 350 155 Q 400 155 450 155 Q 500 155 580 155 Q 650 155 700 200"/>
-    <path d="M 350 240 Q 400 240 450 240 Q 500 240 580 240 Q 650 240 870 220"/>
+  <!-- Foreground arrows (connecting inside elements) -->
+  <g id="foreground-arrows">
+    <!-- Service to Pod Arrows (connecting inside) -->
+    <g stroke="#4caf50" stroke-width="2" fill="none" marker-end="url(#arrowhead-green)">
+      <line x1="760" y1="320" x2="760" y2="420"/>
+      <line x1="930" y1="320" x2="930" y2="420"/>
+      <line x1="760" y1="260" x2="760" y2="320"/>
+      <line x1="930" y1="260" x2="930" y2="320"/>
+    </g>
+    
+    <!-- Control Flow from Operator (connecting inside) -->
+    <g stroke="#666" stroke-width="1" fill="none" stroke-dasharray="2,2">
+      <line x1="560" y1="210" x2="560" y2="240"/>
+      <line x1="640" y1="170" x2="700" y2="200"/>
+      <line x1="640" y1="170" x2="870" y2="200"/>
+      <line x1="560" y1="210" x2="560" y2="520"/>
+    </g>
   </g>
-  
-  <!-- Service to Pod Arrows -->
-  <g id="service-pod-flow" stroke="#4caf50" stroke-width="2" fill="none" marker-end="url(#arrowhead-green)">
-    <line x1="760" y1="320" x2="760" y2="420"/>
-    <line x1="930" y1="320" x2="930" y2="420"/>
-    <line x1="760" y1="260" x2="760" y2="320"/>
-    <line x1="930" y1="260" x2="930" y2="320"/>
-  </g>
-  
-  <!-- Egress Flow Arrows -->
-  <g id="egress-flow" stroke="#ff5722" stroke-width="3" fill="none" marker-end="url(#arrowhead-red)">
-    <path d="M 700 560 Q 650 560 600 560 Q 580 560 560 560"/>
-    <path d="M 480 560 Q 400 560 350 560 Q 300 560 200 235 Q 160 235 160 210"/>
-  </g>
-  
-  <!-- Control Flow from Operator -->
-  <g id="control-flow" stroke="#666" stroke-width="1" fill="none" stroke-dasharray="2,2">
-    <line x1="560" y1="210" x2="560" y2="240"/>
-    <line x1="640" y1="170" x2="700" y2="200"/>
-    <line x1="640" y1="170" x2="870" y2="200"/>
-    <line x1="560" y1="210" x2="560" y2="520"/>
-  </g>
-  
-  <!-- Arrow markers -->
-  <defs>
-    <marker id="arrowhead-blue" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#2196f3"/>
-    </marker>
-    <marker id="arrowhead-green" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#4caf50"/>
-    </marker>
-    <marker id="arrowhead-red" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#ff5722"/>
-    </marker>
-  </defs>
   
   <!-- Flow Labels -->
   <text x="525" y="140" font-family="Arial, sans-serif" font-size="11" fill="#2196f3" font-weight="bold">Ingress Traffic</text>
-  <text x="400" y="580" font-family="Arial, sans-serif" font-size="11" fill="#ff5722" font-weight="bold">Egress Traffic</text>
-  <text x="580" y="290" font-family="Arial, sans-serif" font-size="10" fill="#666">Control</text>
+  <text x="300" y="290" font-family="Arial, sans-serif" font-size="11" fill="#ff5722" font-weight="bold">Egress Traffic</text>
+  <text x="580" y="295" font-family="Arial, sans-serif" font-size="10" fill="#666">Control</text>
+  <text x="390" y="200" font-family="Arial, sans-serif" font-size="10" fill="#673ab7" font-weight="bold">Tailnet</text>
   
   <!-- Legend -->
-  <g id="legend" transform="translate(50, 720)">
+  <g id="legend" transform="translate(50, 750)">
     <text x="0" y="0" font-family="Arial, sans-serif" font-size="14" font-weight="bold">Traffic Flows:</text>
     
     <line x1="0" y1="20" x2="40" y2="20" stroke="#2196f3" stroke-width="3" marker-end="url(#arrowhead-blue)"/>
@@ -145,16 +168,23 @@
     <line x1="0" y1="40" x2="40" y2="40" stroke="#ff5722" stroke-width="3" marker-end="url(#arrowhead-red)"/>
     <text x="50" y="45" font-family="Arial, sans-serif" font-size="12">Egress: K8s Pods → External Resources</text>
     
-    <line x1="0" y1="60" x2="40" y2="60" stroke="#666" stroke-width="1" stroke-dasharray="2,2"/>
-    <text x="50" y="65" font-family="Arial, sans-serif" font-size="12">Control: Operator Management</text>
+    <line x1="0" y1="60" x2="40" y2="60" stroke="#673ab7" stroke-width="3" stroke-dasharray="10,5" marker-end="url(#arrowhead-tailnet)"/>
+    <text x="50" y="65" font-family="Arial, sans-serif" font-size="12">Tailnet Connection</text>
+    
+    <line x1="0" y1="80" x2="40" y2="80" stroke="#666" stroke-width="1" stroke-dasharray="2,2"/>
+    <text x="50" y="85" font-family="Arial, sans-serif" font-size="12">Control: Operator Management</text>
+    
+    <circle cx="20" cy="105" r="6" fill="#673ab7" stroke="#4a148c" stroke-width="1"/>
+    <text x="20" y="108" text-anchor="middle" font-family="Arial, sans-serif" font-size="6" fill="white" font-weight="bold">T</text>
+    <text x="50" y="110" font-family="Arial, sans-serif" font-size="12">Tailnet Member</text>
   </g>
   
   <!-- Features Box -->
-  <rect x="750" y="620" width="320" height="140" fill="#f5f5f5" stroke="#ddd" stroke-width="1" rx="5"/>
-  <text x="910" y="645" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" font-weight="bold">Operator Features</text>
-  <text x="770" y="670" font-family="Arial, sans-serif" font-size="12">• Automatic proxy pod deployment</text>
-  <text x="770" y="690" font-family="Arial, sans-serif" font-size="12">• Service discovery integration</text>
-  <text x="770" y="710" font-family="Arial, sans-serif" font-size="12">• ProxyClass resource management</text>
-  <text x="770" y="730" font-family="Arial, sans-serif" font-size="12">• Ingress annotation support</text>
-  <text x="770" y="750" font-family="Arial, sans-serif" font-size="12">• Subnet routing capabilities</text>
+  <rect x="750" y="730" width="320" height="140" fill="#f5f5f5" stroke="#ddd" stroke-width="1" rx="5"/>
+  <text x="910" y="755" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" font-weight="bold">Operator Features</text>
+  <text x="770" y="780" font-family="Arial, sans-serif" font-size="12">• Automatic proxy pod deployment</text>
+  <text x="770" y="800" font-family="Arial, sans-serif" font-size="12">• Service discovery integration</text>
+  <text x="770" y="820" font-family="Arial, sans-serif" font-size="12">• ProxyClass resource management</text>
+  <text x="770" y="840" font-family="Arial, sans-serif" font-size="12">• Ingress annotation support</text>
+  <text x="770" y="860" font-family="Arial, sans-serif" font-size="12">• Subnet routing capabilities</text>
 </svg>


### PR DESCRIPTION
This PR fixes several issues with the Tailscale Kubernetes Operator proxy diagram:

**Fixes:**
- Fixed arrow layering with proper background/foreground separation
- Replaced complex curved arrows with clean straight lines
- Increased SVG height from 800px to 900px to prevent text cutoff
- Added Tailnet connection indicators (purple 'T' badges) on proxy pods
- Added dashed purple lines showing Tailnet membership
- Updated legend to include Tailnet connection types
- Improved visual clarity of ingress/egress proxy flows

Addresses feedback from # ##3

🤖 Generated with [Claude Code](https://claude.ai/code)