### PR TITLE
Fix Tailscale K8s operator diagram layering and Tailnet visualization

### DIFF
--- a/content/diagrams/network/tailscale-k8s-operator-proxy/tailscale-k8s-operator-proxy.svg
+++ b/content/diagrams/network/tailscale-k8s-operator-proxy/tailscale-k8s-operator-proxy.svg
@@ -1,12 +1,12 @@
-<svg width="1100" height="800" xmlns="http://www.w3.org/2000/svg">
-  <rect width="1100" height="800" fill="#f8f9fa"/>
+<svg width="1100" height="1000" viewBox="0 0 1100 1000" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1100" height="1000" fill="#f8f9fa"/>
   
   <!-- Title -->
   <text x="550" y="35" text-anchor="middle" font-family="Arial, sans-serif" font-size="24" font-weight="bold">Tailscale Kubernetes Operator Proxy Architecture</text>
   
   <!-- External Tailscale Network -->
-  <rect x="50" y="80" width="300" height="200" fill="#e3f2fd" stroke="#2196f3" stroke-width="2" rx="10" stroke-dasharray="5,5"/>
-  <text x="200" y="105" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="#1976d2">Tailscale Network</text>
+  <rect x="50" y="80" width="300" height="200" fill="#f3e5f5" stroke="#673ab7" stroke-width="2" rx="10" stroke-dasharray="5,5"/>
+  <text x="200" y="105" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="#673ab7">Tailscale Network (Tailnet)</text>
   
   <!-- External Clients -->
   <rect x="80" y="130" width="80" height="50" fill="#2196f3" stroke="#1976d2" stroke-width="2" rx="5"/>
@@ -48,12 +48,18 @@
     <text x="760" y="225" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#e3f2fd">web-service</text>
     <text x="760" y="240" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#bbdefb">100.64.0.10</text>
     <text x="760" y="255" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#90caf9">Port: 80</text>
+    <!-- Tailnet indicator -->
+    <circle cx="805" cy="195" r="12" fill="#673ab7" stroke="white" stroke-width="1"/>
+    <text x="805" y="200" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="white" font-weight="bold">T</text>
     
     <rect x="870" y="180" width="120" height="80" fill="#2196f3" stroke="#1976d2" stroke-width="2" rx="5"/>
     <text x="930" y="205" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white" font-weight="bold">Ingress Proxy</text>
     <text x="930" y="225" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#e3f2fd">api-service</text>
     <text x="930" y="240" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#bbdefb">100.64.0.12</text>
     <text x="930" y="255" text-anchor="middle" font-family="Arial, sans-serif" font-size="9" fill="#90caf9">Port: 8080</text>
+    <!-- Tailnet indicator -->
+    <circle cx="975" cy="195" r="12" fill="#673ab7" stroke="white" stroke-width="1"/>
+    <text x="975" y="200" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="white" font-weight="bold">T</text>
   </g>
   
   <!-- Kubernetes Services -->
@@ -83,16 +89,26 @@
   <text x="560" y="545" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="white" font-weight="bold">Egress Proxy</text>
   <text x="560" y="565" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#ffccbc">external-access</text>
   <text x="560" y="580" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#ffab91">Routes to External</text>
+  <!-- Tailnet indicator -->
+  <circle cx="625" cy="535" r="12" fill="#673ab7" stroke="white" stroke-width="1"/>
+  <text x="625" y="540" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="white" font-weight="bold">T</text>
   
   <!-- Client Pod needing external access -->
   <rect x="700" y="530" width="120" height="60" fill="#795548" stroke="#5d4037" stroke-width="2" rx="5"/>
   <text x="760" y="555" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="white" font-weight="bold">client-pod</text>
   <text x="760" y="575" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" fill="#d7ccc8">Needs External DB</text>
   
+  <!-- Background: Tailnet Connection Lines -->
+  <g id="tailnet-connections" stroke="#673ab7" stroke-width="2" fill="none" stroke-dasharray="5,5" opacity="0.7">
+    <line x1="350" y1="155" x2="805" y2="195"/>
+    <line x1="350" y1="235" x2="975" y2="195"/>
+    <line x1="350" y1="200" x2="625" y2="535"/>
+  </g>
+
   <!-- Ingress Flow Arrows -->
   <g id="ingress-flow" stroke="#2196f3" stroke-width="3" fill="none" marker-end="url(#arrowhead-blue)">
-    <path d="M 350 155 Q 400 155 450 155 Q 500 155 580 155 Q 650 155 700 200"/>
-    <path d="M 350 240 Q 400 240 450 240 Q 500 240 580 240 Q 650 240 870 220"/>
+    <line x1="350" y1="155" x2="700" y2="200"/>
+    <line x1="350" y1="235" x2="870" y2="220"/>
   </g>
   
   <!-- Service to Pod Arrows -->
@@ -105,8 +121,8 @@
   
   <!-- Egress Flow Arrows -->
   <g id="egress-flow" stroke="#ff5722" stroke-width="3" fill="none" marker-end="url(#arrowhead-red)">
-    <path d="M 700 560 Q 650 560 600 560 Q 580 560 560 560"/>
-    <path d="M 480 560 Q 400 560 350 560 Q 300 560 200 235 Q 160 235 160 210"/>
+    <line x1="700" y1="560" x2="640" y2="560"/>
+    <line x1="480" y1="560" x2="160" y2="235"/>
   </g>
   
   <!-- Control Flow from Operator -->
@@ -128,6 +144,9 @@
     <marker id="arrowhead-red" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#ff5722"/>
     </marker>
+    <marker id="arrowhead-purple" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#673ab7"/>
+    </marker>
   </defs>
   
   <!-- Flow Labels -->
@@ -136,7 +155,7 @@
   <text x="580" y="290" font-family="Arial, sans-serif" font-size="10" fill="#666">Control</text>
   
   <!-- Legend -->
-  <g id="legend" transform="translate(50, 720)">
+  <g id="legend" transform="translate(50, 840)">
     <text x="0" y="0" font-family="Arial, sans-serif" font-size="14" font-weight="bold">Traffic Flows:</text>
     
     <line x1="0" y1="20" x2="40" y2="20" stroke="#2196f3" stroke-width="3" marker-end="url(#arrowhead-blue)"/>
@@ -145,16 +164,24 @@
     <line x1="0" y1="40" x2="40" y2="40" stroke="#ff5722" stroke-width="3" marker-end="url(#arrowhead-red)"/>
     <text x="50" y="45" font-family="Arial, sans-serif" font-size="12">Egress: K8s Pods → External Resources</text>
     
-    <line x1="0" y1="60" x2="40" y2="60" stroke="#666" stroke-width="1" stroke-dasharray="2,2"/>
-    <text x="50" y="65" font-family="Arial, sans-serif" font-size="12">Control: Operator Management</text>
+    <line x1="0" y1="60" x2="40" y2="60" stroke="#673ab7" stroke-width="2" stroke-dasharray="5,5"/>
+    <text x="50" y="65" font-family="Arial, sans-serif" font-size="12">Tailnet: Tailscale Network Connections</text>
+    
+    <line x1="0" y1="80" x2="40" y2="80" stroke="#666" stroke-width="1" stroke-dasharray="2,2"/>
+    <text x="50" y="85" font-family="Arial, sans-serif" font-size="12">Control: Operator Management</text>
+    
+    <circle cx="10" cy="105" r="8" fill="#673ab7" stroke="white" stroke-width="1"/>
+    <text x="10" y="108" text-anchor="middle" font-family="Arial, sans-serif" font-size="8" fill="white" font-weight="bold">T</text>
+    <text x="25" y="110" font-family="Arial, sans-serif" font-size="12">Tailnet Member</text>
   </g>
   
   <!-- Features Box -->
-  <rect x="750" y="620" width="320" height="140" fill="#f5f5f5" stroke="#ddd" stroke-width="1" rx="5"/>
-  <text x="910" y="645" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" font-weight="bold">Operator Features</text>
-  <text x="770" y="670" font-family="Arial, sans-serif" font-size="12">• Automatic proxy pod deployment</text>
-  <text x="770" y="690" font-family="Arial, sans-serif" font-size="12">• Service discovery integration</text>
-  <text x="770" y="710" font-family="Arial, sans-serif" font-size="12">• ProxyClass resource management</text>
-  <text x="770" y="730" font-family="Arial, sans-serif" font-size="12">• Ingress annotation support</text>
-  <text x="770" y="750" font-family="Arial, sans-serif" font-size="12">• Subnet routing capabilities</text>
+  <rect x="750" y="720" width="320" height="160" fill="#f5f5f5" stroke="#ddd" stroke-width="1" rx="5"/>
+  <text x="910" y="745" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" font-weight="bold">Operator Features</text>
+  <text x="770" y="770" font-family="Arial, sans-serif" font-size="12">• Automatic proxy pod deployment</text>
+  <text x="770" y="790" font-family="Arial, sans-serif" font-size="12">• Service discovery integration</text>
+  <text x="770" y="810" font-family="Arial, sans-serif" font-size="12">• ProxyClass resource management</text>
+  <text x="770" y="830" font-family="Arial, sans-serif" font-size="12">• Ingress annotation support</text>
+  <text x="770" y="850" font-family="Arial, sans-serif" font-size="12">• Subnet routing capabilities</text>
+  <text x="770" y="870" font-family="Arial, sans-serif" font-size="12">• Tailnet mesh integration</text>
 </svg>


### PR DESCRIPTION
This PR fixes several issues with the Tailscale Kubernetes Operator proxy diagram:

**Fixes:**
- Fixed arrow layering with proper background/foreground separation
- Replaced complex curved arrows with clean straight lines
- Increased SVG height from 800px to 1000px to prevent text cutoff
- Added Tailnet connection indicators (purple 'T' badges) on proxy pods
- Added dashed purple lines showing Tailnet membership
- Updated legend to include Tailnet connection types
- Improved visual clarity of ingress/egress proxy flows

Addresses feedback from # 3

🤖 Generated with [Claude Code](https://claude.ai/code)