### PR TITLE
fix: update architecture section featured image references

### DIFF
--- a/content/diagrams/architecture/_index.md
+++ b/content/diagrams/architecture/_index.md
@@ -5,9 +5,9 @@ date: 2025-01-23
 categories: ["Technical"]
 tags: ["architecture", "system-design"]
 params:
-  featured_image: microservices-architecture.svg
+  featured_image: claude-diagrams-overview.svg
 resources:
-  - src: microservices-architecture.svg
+  - src: claude-diagrams-overview.svg
     name: featured
 ---
 


### PR DESCRIPTION
Replace broken microservices-architecture.svg references with claude-diagrams-overview.svg to fix site build issues caused by PR #12 diagram removal.

Generated with [Claude Code](https://claude.ai/code)